### PR TITLE
Changed about page location

### DIFF
--- a/admin/class-admin-pages.php
+++ b/admin/class-admin-pages.php
@@ -68,9 +68,9 @@ class Controlled_Chaos_Admin_Pages {
     public function about_plugin() {
 
         add_submenu_page(
-            null, 
-            'About Page',
-            'About Page', 
+            'plugins.php', 
+            'Site Plugin',
+            'Site Plugin', 
             'manage_options', 
             'controlled-chaos-page', 
             [ $this, 'plugin_about_page' ]

--- a/controlled-chaos.php
+++ b/controlled-chaos.php
@@ -91,10 +91,10 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-includes.php';
  * Add a link to the plugin's about page on the plugins page.
  * 
  * The about page in its original form is intended to be read by
- * developers for getting familiar with the plugin, so it is not
- * included in the admin menu.
+ * developers for getting familiar with the plugin, so it is
+ * included in the admin menu under plugins.
  * 
- * If you would like to show the page as you make it your own then
+ * If you would like to link the page elsewhere as you make it your own then
  * do so in admin/class-admin-pages.php, in the about_plugin method.
  * 
  * @since 1.0.0
@@ -105,7 +105,7 @@ function controlled_chaos_settings_link( $links ) {
 
 	// Create the link element.
 	$about_page = [
-		sprintf( '<a href="%1s" class="controlled-chaos-about-link">%2s</a>', admin_url( 'options-general.php?page=controlled-chaos-page' ), esc_attr( 'Documentation', 'controlled-chaos' ) ),
+		sprintf( '<a href="%1s" class="controlled-chaos-about-link">%2s</a>', admin_url( 'plugins.php?page=controlled-chaos-page' ), esc_attr( 'Documentation', 'controlled-chaos' ) ),
 	];
 
 	// Merge the about link with the default links.


### PR DESCRIPTION
I thought it better that the plugin page not be hidden from the admin
menu, and that it ought to live, as it is out of the box, under the
"Plugins" tab.